### PR TITLE
Add clipboard debug and color parsing

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -5,5 +5,7 @@
     <Grid>
         <Button Content="変換" Width="100" Height="40" HorizontalAlignment="Center" VerticalAlignment="Center"
                 Click="OnConvertClick"/>
+        <Button Content="デバッグ" Width="80" Height="30" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="10"
+                Click="OnDebugClick"/>
     </Grid>
 </Window>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System.Windows;
 using System;
 using Services;
+using System.Windows.Forms;
 
 public partial class MainWindow : Window{
         public MainWindow(){
@@ -10,5 +11,14 @@ public partial class MainWindow : Window{
         private void OnConvertClick(object sender, RoutedEventArgs e){
             EmfGenerator generator = new EmfGenerator();
             generator.ConvertClipboardHtmlTableToEmf();
+        }
+
+        private void OnDebugClick(object sender, RoutedEventArgs e){
+            if (Clipboard.ContainsText(TextDataFormat.Html)){
+                string html = Clipboard.GetText(TextDataFormat.Html);
+                System.Windows.MessageBox.Show(html, "Clipboard HTML");
+            } else {
+                System.Windows.MessageBox.Show("クリップボードにHTMLデータがありません", "Clipboard HTML");
+            }
         }
     }

--- a/Services/EmfGenerator.cs
+++ b/Services/EmfGenerator.cs
@@ -70,8 +70,6 @@ namespace Services{
                             }
 
                             RectangleF rect = new RectangleF(x, y, width, height);
-                            graphics.DrawRectangle(Pens.Black, rect.X, rect.Y, rect.Width, rect.Height);
-                            graphics.DrawString(cell.Text, font, Brushes.Black, rect.X + padding, rect.Y + 4);
 
                             // セル描画処理内（cell に対する処理の中）
                             Pen pen = new Pen(Color.Black, 1.0f);

--- a/Utils/HTML/Parser.cs
+++ b/Utils/HTML/Parser.cs
@@ -110,8 +110,9 @@ namespace Utils.HTML{
                 if (parts.Length == 2){
                     string key = parts[0].Trim().ToLower();
                     string value = parts[1].Trim();
-                    if (key == "background-color"){
-                        return value;
+                    if (key == "background-color" || key == "background"){
+                        // "background" may contain multiple values; first token is color
+                        return value.Split(' ')[0];
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- parse CSS `background` style for cell colors
- show clipboard HTML via new debug button
- draw cell background in EMF without duplicate operations

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858399fcccc8326a260722fdadf5aa9