### PR TITLE
Add SVG clipboard handling and viewer update

### DIFF
--- a/MainWindow.xaml
+++ b/MainWindow.xaml
@@ -5,8 +5,8 @@
     <Grid>
         <Button Content="変換" Width="100" Height="40" HorizontalAlignment="Center" VerticalAlignment="Center"
                 Click="OnConvertClick"/>
-        <Button Content="▣" Width="30" Height="30" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="4"
-                Click="OnDebugClick"/>
+        <Button Content="表示" Width="50" Height="30" HorizontalAlignment="Right" VerticalAlignment="Bottom" Margin="4"
+                Click="OnViewClipboardClick"/>
         <!-- 画像リサイズ用UI追加 -->
         <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" VerticalAlignment="Bottom" Margin="10,0,0,10">
             <TextBox x:Name="ResizeScaleTextBox" Width="60" Height="28" Text="100" VerticalAlignment="Center" Margin="0,0,8,0"/>

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -9,6 +9,7 @@ using System.Windows.Controls;
 using System.Drawing.Drawing2D;
 using System.Drawing;
 using System.Drawing.Imaging;
+using Utils;
 
 public partial class MainWindow : Window{
     // Win32 API 定義
@@ -65,33 +66,57 @@ public partial class MainWindow : Window{
     }
 
     private void OnConvertClick(object sender, RoutedEventArgs e){
-        _emfGenerator.ConvertClipboardHtmlTableToEmf();
+        if (Clipboard.ContainsText(TextDataFormat.Html)){
+            _emfGenerator.ConvertClipboardHtmlTableToEmf();
+            return;
+        }
+
+        if (Clipboard.ContainsText()){
+            string text = Clipboard.GetText();
+            if (SvgClipboardHelper.IsSvgText(text)){
+                SvgClipboardHelper.SetSvgFormat(text);
+                MessageBox.Show("SVGフォーマットをクリップボードに生成しました。", "SVG" );
+                return;
+            }
+        }
+
+        MessageBox.Show("クリップボードにHTMLまたはSVGデータがありません。", "エラー");
     }
 
-    private void OnDebugClick(object sender, RoutedEventArgs e){
+    private void OnViewClipboardClick(object sender, RoutedEventArgs e){
         if (Clipboard.ContainsText(TextDataFormat.Html)){
             string html = Clipboard.GetText(TextDataFormat.Html);
-            // カスタムウィンドウでHTMLを表示（スクロール・サイズ指定）
-            Window htmlWindow = new Window{
-                Title = "Clipboard HTML",
-                Width = 800,
-                Height = 600,
-                Content = new ScrollViewer{
-                    Content = new TextBox{
-                        Text = html,
-                        IsReadOnly = true,
-                        AcceptsReturn = true,
-                        AcceptsTab = true,
-                        VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
-                        HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
-                        TextWrapping = TextWrapping.NoWrap
-                    }
-                }
-            };
-            htmlWindow.ShowDialog();
-        } else {
-            MessageBox.Show("クリップボードにHTMLデータがありません", "Clipboard HTML");
+            ShowTextWindow(html, "Clipboard HTML");
+            return;
         }
+
+        if (Clipboard.ContainsText()){
+            string text = Clipboard.GetText();
+            ShowTextWindow(text, "Clipboard Text");
+            return;
+        }
+
+        MessageBox.Show("クリップボードに表示可能なデータがありません", "Clipboard");
+    }
+
+    private void ShowTextWindow(string text, string title){
+        Window window = new Window{
+            Title = title,
+            Width = 800,
+            Height = 600,
+            Content = new ScrollViewer{
+                Content = new TextBox{
+                    Text = text,
+                    IsReadOnly = true,
+                    AcceptsReturn = true,
+                    AcceptsTab = true,
+                    VerticalScrollBarVisibility = ScrollBarVisibility.Auto,
+                    HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
+                    TextWrapping = TextWrapping.NoWrap
+                }
+            }
+        };
+        window.ShowDialog();
     }
 
     private void OnResizeImageClick(object sender, RoutedEventArgs e){

--- a/Utils/SvgClipboardHelper.cs
+++ b/Utils/SvgClipboardHelper.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Windows;
+
+namespace Utils{
+    public static class SvgClipboardHelper{
+        // SVG文字列かどうか判定
+        public static bool IsSvgText(string text){
+            if(string.IsNullOrWhiteSpace(text)) return false;
+            string trimmed = text.TrimStart();
+            if(trimmed.StartsWith("<?xml", StringComparison.OrdinalIgnoreCase)){
+                int index = trimmed.IndexOf("<svg", StringComparison.OrdinalIgnoreCase);
+                return index >= 0;
+            }
+            return trimmed.StartsWith("<svg", StringComparison.OrdinalIgnoreCase);
+        }
+
+        // SVGフォーマットをクリップボードに設定
+        public static void SetSvgFormat(string svgText){
+            DataObject obj = new DataObject();
+            obj.SetData(DataFormats.UnicodeText, svgText);
+            obj.SetData(DataFormats.Text, svgText);
+            obj.SetData("image/svg+xml", svgText);
+            Clipboard.SetDataObject(obj, true);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- support converting plain SVG clipboard text to a proper SVG clipboard format
- show clipboard text even if not HTML
- rename and extend the debug button to view clipboard contents

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887cffeadf48326a07037fc3c82b967